### PR TITLE
Let the wrapping Promise handle network errors thrown by getUserId

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -171,9 +171,7 @@ const connect = options => new Promise((resolve, reject) => {
     }
 
     client.connect(connectionOpts);
-  }, (error) => {
-    throw new Error(error);
-  });
+  }, reject);
 });
 
 const disconnect = id => new Promise((resolve, reject) => {


### PR DESCRIPTION
Network errors thrown by the `getUserId` are thrown not rejected by the `connect` Promise.
Let this Promise handle them so they can be catched downstream.