### PR TITLE
Clean up the properties callbacks upon disconnect

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -199,6 +199,21 @@ const disconnect = id => new Promise((resolve, reject) => {
   }
 
   client.disconnect();
+
+  // Remove property callbacks to allow resubscribing in a later connect()
+  Object.keys(propertyCallback).forEach((topic) => {
+    if (propertyCallback[topic]) {
+      delete propertyCallback[topic];
+    }
+  });
+
+  // Clean up subscribed topics - a new connection might not need the same topics
+  Object.keys(subscribedTopics).forEach((topic) => {
+    if (subscribedTopics[topic]) {
+      delete subscribedTopics[topic];
+    }
+  });
+
   return resolve();
 });
 


### PR DESCRIPTION
Clean up the property callbacks upon disconnect. Because of [this](https://github.com/arduino/arduino-iot-js/blob/5dfe8f6f4492d6e0427cce4ff132bc836aeb9b44/src/index.js#L376) if `connect()` is called after a `disconnect()`, the subscription to the Things topics is not done again, and it is impossible to do it without invoking a `subscribe()`. 