### PR TITLE
Single connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,48 +24,48 @@ import ArduinoCloud from 'arduino-iot-js';
 //   apiUrl: 'AUTH SERVER URL', // Default is https://auth.arduino.cc
 //   onDisconnect: message => { /* Disconnection callback */ }
 // }
-ArduinoCloud.connect(options).then(connectionId => {
+ArduinoCloud.connect(options).then(() => {
   // Connected
 });
 
-ArduinoCloud.disconnect(connectionId).then(() => {
+ArduinoCloud.disconnect().then(() => {
   // Disconnected
 });
 
-ArduinoCloud.subscribe(connectionId, topic, cb).then(topic => {
+ArduinoCloud.subscribe(topic, cb).then(topic => {
   // Subscribed to topic, messaged fired in the cb
 });
 
-ArduinoCloud.unsubscribe(connectionId, topic).then(topic => {
+ArduinoCloud.unsubscribe(topic).then(topic => {
   // Unsubscribed to topic
 });
 
-ArduinoCloud.sendMessage(connectionId, topic, message).then(() => {
+ArduinoCloud.sendMessage(topic, message).then(() => {
   // Message sent
 });
 
-ArduinoCloud.openCloudMonitor(connectionId, deviceId, cb).then(topic => {
+ArduinoCloud.openCloudMonitor(deviceId, cb).then(topic => {
   // Cloud monitor messages fired to cb
 });
 
-ArduinoCloud.writeCloudMonitor(connectionId, deviceId, message).then(() => {
+ArduinoCloud.writeCloudMonitor(deviceId, message).then(() => {
   // Message sent to cloud monitor
 });
 
-ArduinoCloud.closeCloudMonitor(connectionId, deviceId).then(topic => {
+ArduinoCloud.closeCloudMonitor(deviceId).then(topic => {
   // Close cloud monitor
 });
 
 // Send a property value to a device
 // - value can be a string, a boolean or a number
 // - timestamp is a unix timestamp, not required
-ArduinoCloud.sendProperty(connectionId, thingId, name, value, timestamp).then(() => {
+ArduinoCloud.sendProperty(thingId, name, value, timestamp).then(() => {
   // Property value sent
 });
 
 // Register a callback on a property value change
 // 
-ArduinoCloud.onPropertyValue(connectionId, thingId, propertyName, updateCb).then(() => {
+ArduinoCloud.onPropertyValue(thingId, propertyName, updateCb).then(() => {
   // updateCb(message) will be called every time a new value is available. Value can be string, number, or a boolean depending on the property type
 });
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ ArduinoCloud.onPropertyValue(thingId, propertyName, updateCb).then(() => {
   // updateCb(message) will be called every time a new value is available. Value can be string, number, or a boolean depending on the property type
 });
 
+// Re-connect with a new authentication token, keeping the subscriptions
+// to the Things topics
+ArduinoCloud.updateToken(newToken).then(() => {
+  // Successful reconnection with the provided new token
+});
+
 ```
 
 ## Run tests

--- a/test/arduino-cloud.test.js
+++ b/test/arduino-cloud.test.js
@@ -19,9 +19,8 @@
 */
 const ArduinoCloud = require('../dist/index.js');
 
-let connectionId;
 const deviceId = '1f4ced70-53ad-4b29-b221-1b0abbdfc757';
-const thingId = '2cea8542-d472-4464-859c-4ef4dfc7d1d3'
+const thingId = '2cea8542-d472-4464-859c-4ef4dfc7d1d3';
 const propertyIntName = 'integer';
 const propertyIntValue = 22;
 
@@ -34,27 +33,27 @@ const propertyStrVal = 'ok';
 const propertyBoolName = 'boolean';
 const propertyBoolVal = true;
 
-it('ArduinoCloud connection', () => {
-  expect.assertions(1);
+it('ArduinoCloud connection', (done) => {
   /* global token */
-  return ArduinoCloud.connect({
+  ArduinoCloud.connect({
     token,
     onDisconnect: (message) => {
       if (message.errorCode !== 0) {
         throw Error(message);
       }
     },
-  }).then((id) => {
-    connectionId = id;
-    expect(id).toBeDefined();
-  }, (error) => {
-    throw new Error(error);
-  });
+  })
+    .then(() => {
+      done();
+    })
+    .catch((error) => {
+      throw new Error(error);
+    });
 });
 
 it('Property name must be a string in sendProperty', (done) => {
   try {
-    ArduinoCloud.sendProperty(connectionId, deviceId, undefined, propertyIntValue);
+    ArduinoCloud.sendProperty(deviceId, undefined, propertyIntValue);
   } catch (error) {
     if (error.message === 'Name must be a valid string') {
       done();
@@ -63,7 +62,7 @@ it('Property name must be a string in sendProperty', (done) => {
 });
 
 it('Simulate client write to cloud monitor', (done) => {
-  ArduinoCloud.writeCloudMonitor(connectionId, deviceId, `this is a test ${Math.random()}`).then(() => {
+  ArduinoCloud.writeCloudMonitor(deviceId, `this is a test ${Math.random()}`).then(() => {
     done();
   }, (error) => {
     throw new Error(error);
@@ -72,7 +71,7 @@ it('Simulate client write to cloud monitor', (done) => {
 
 it('Simulate device write to cloud monitor', (done) => {
   const cloudMonitorInputTopic = `/a/d/${deviceId}/s/o`;
-  ArduinoCloud.sendMessage(connectionId, cloudMonitorInputTopic, `this is a test ${Math.random()}`).then(() => {
+  ArduinoCloud.sendMessage(cloudMonitorInputTopic, `this is a test ${Math.random()}`).then(() => {
     done();
   }, (error) => {
     throw new Error(error);
@@ -87,10 +86,10 @@ it('Simulate device write and client read his message from cloud monitor', (done
     done();
   };
 
-  ArduinoCloud.openCloudMonitor(connectionId, deviceId, cb).then(() => {
+  ArduinoCloud.openCloudMonitor(deviceId, cb).then(() => {
     // console.log(`Subscribed to topic: ${topic}`);
     const message = `This is a test ${new Date()}`;
-    ArduinoCloud.sendMessage(connectionId, cloudMonitorInputTopic, message).then(() => {
+    ArduinoCloud.sendMessage(cloudMonitorInputTopic, message).then(() => {
     // console.log(`[${new Date()}] Message sent to monitor: [${message}]`);
     }, (error) => {
       throw new Error(error);
@@ -101,42 +100,42 @@ it('Simulate device write and client read his message from cloud monitor', (done
 });
 
 it('Simulate client read integer property sent by device', (done) => {
-  ArduinoCloud.onPropertyValue(connectionId, thingId, propertyIntName, (value) => {
+  ArduinoCloud.onPropertyValue(thingId, propertyIntName, (value) => {
     if (value === propertyIntValue) {
       done();
     }
   }).then(() => {
-    ArduinoCloud.sendPropertyAsDevice(connectionId, deviceId, thingId, propertyIntName, propertyIntValue);
+    ArduinoCloud.sendPropertyAsDevice(deviceId, thingId, propertyIntName, propertyIntValue);
   });
 });
 
 it('Simulate client read float property sent by device', (done) => {
-  ArduinoCloud.onPropertyValue(connectionId, thingId, propertyFloatName, (value) => {
+  ArduinoCloud.onPropertyValue(thingId, propertyFloatName, (value) => {
     if (value === propertyFloatVal) {
       done();
     }
   }).then(() => {
-    ArduinoCloud.sendPropertyAsDevice(connectionId, deviceId, thingId, propertyFloatName, propertyFloatVal);
+    ArduinoCloud.sendPropertyAsDevice(deviceId, thingId, propertyFloatName, propertyFloatVal);
   });
 });
 
 it('Simulate client read string property sent by device', (done) => {
-  ArduinoCloud.onPropertyValue(connectionId, thingId, propertyStrName, (value) => {
+  ArduinoCloud.onPropertyValue(thingId, propertyStrName, (value) => {
     if (value === propertyStrVal) {
       done();
     }
   }).then(() => {
-    ArduinoCloud.sendPropertyAsDevice(connectionId, deviceId, thingId, propertyStrName, propertyStrVal);
+    ArduinoCloud.sendPropertyAsDevice(deviceId, thingId, propertyStrName, propertyStrVal);
   });
 });
 
 it('Simulate client read boolean property sent by device', (done) => {
-  ArduinoCloud.onPropertyValue(connectionId, thingId, propertyBoolName, (value) => {
+  ArduinoCloud.onPropertyValue(thingId, propertyBoolName, (value) => {
     if (value === propertyBoolVal) {
-      ArduinoCloud.disconnect(connectionId);
+      ArduinoCloud.disconnect();
       done();
     }
   }).then(() => {
-    ArduinoCloud.sendPropertyAsDevice(connectionId, deviceId, thingId, propertyBoolName, propertyBoolVal);
+    ArduinoCloud.sendPropertyAsDevice(deviceId, thingId, propertyBoolName, propertyBoolVal);
   });
 });


### PR DESCRIPTION
Drop the multiple connections feature.
At this moment, it makes no sense for a single user to create multiple connections to IoT Cloud, since the messages for all the things comes through the same single connection. Creating connections for multiple users at the moment is not supported anyway, because there is no way to authenticate with different tokens, and the profile API is called for the currently authenticated user.
Creating multiple connections for the same user is still possible, but may create confusing situations where some of them are in a connected status and others aren't.
This PR enforces the creation of a single connection at time, requiring to close the currently opened one before opening a new one.
An `updateToken` function is added to allow simplify the token upgrade process, without requiring the ArduinoIoTJs user to close and reopen the connection when the authentication token is expired.