### PR TITLE
Add override MQTT Library option

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,19 @@ ArduinoIoTCloud.connect(options)
   .catch(error => console.error(error));
 ```
 
+## Override MQTT Library
+
+If for any reason (e.g., a `React Native` project) the standard [mqtt library](https://github.com/mqttjs/MQTT.js) causes issues, it's possible to override it using `ArduinoIoTCloudFactory`.
+
+```ts
+import { ArduinoIoTCloudFactory, MqttConnect, ConnectionOptions } from 'arduino-iot-js';
+
+const connect = (url: string, options: ConnectionOptions) => // Put your library here (es. new Paho.MQTT.Client(options.host, Number(options.port)); )
+
+const ArduinoIoTCloud = ArduinoIoTCloudFactory(connect);
+
+```
+
 ## Development
 
 ### Testing

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arduino-iot-js",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "license": "GPLv3",
   "description": "JS module providing Arduino Create IoT Cloud Connection",
   "main": "./lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arduino-iot-js",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "license": "GPLv3",
   "description": "JS module providing Arduino Create IoT Cloud Connection",
   "main": "./lib/index.js",

--- a/src/builder/APIConnectionBuilder.ts
+++ b/src/builder/APIConnectionBuilder.ts
@@ -1,4 +1,4 @@
-import { MqttClient } from 'mqtt';
+import { MqttConnect } from '../mqtt/IMqttClient';
 import { IHttpClient } from '../http/IHttpClient';
 import { Connection } from '../connection/Connection';
 import { IConnection } from '../connection/IConnection';
@@ -16,7 +16,7 @@ function isApiOptions(options: CloudOptions): options is APIOptions {
 }
 
 export class APIConnectionBuilder implements IConnectionBuilder {
-  constructor(private client: IHttpClient, private mqttConnect: (string, IClientOptions) => MqttClient) {}
+  constructor(private client: IHttpClient, private mqttConnect: MqttConnect) {}
 
   public canBuild(options: CloudOptions): boolean {
     return isApiOptions(options);

--- a/src/builder/TokenConnectionBuilder.ts
+++ b/src/builder/TokenConnectionBuilder.ts
@@ -1,11 +1,11 @@
-import { MqttClient } from 'mqtt';
+import { MqttConnect } from '../mqtt/IMqttClient';
 import { Connection } from '../connection/Connection';
 import { IConnection } from '../connection/IConnection';
 import { IConnectionBuilder } from './IConnectionBuilder';
 import { BrowserOptions, CloudOptions, BaseCloudOptions } from '../client/ICloudClient';
 
 export class TokenConnectionBuilder implements IConnectionBuilder {
-  constructor(private mqttConnect: (string, IClientOptions) => MqttClient) {}
+  constructor(private mqttConnect: MqttConnect) {}
 
   canBuild(options: CloudOptions): boolean {
     return !!(options as BrowserOptions).token;

--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -50,7 +50,7 @@ export class Connection implements IConnection {
     };
 
     const connection = new Connection();
-    connection.client = mqttConnect(`wss://${host}:${port}/mqtt`, {
+    connection.client = await mqttConnect(`wss://${host}:${port}/mqtt`, {
       ...BaseConnectionOptions,
       ...options,
     });

--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -47,6 +47,8 @@ export class Connection implements IConnection {
       clientId: `${userId}:${new Date().getTime()}`,
       username: userId,
       password: token,
+      host,
+      port: Number(port),
     };
 
     const connection = new Connection();

--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -1,8 +1,8 @@
-import mqtt from 'mqtt';
 import { Observable, Subject } from 'rxjs';
 
 import SenML from '../senML';
 import Utils from '../utils';
+import { IMqttClient, MqttConnect } from '../mqtt/IMqttClient';
 import { CloudMessageValue } from '../client/ICloudClient';
 import { IConnection, CloudMessage, ConnectionOptions } from './IConnection';
 
@@ -18,12 +18,12 @@ export class Connection implements IConnection {
   public token: string;
   public messages: Observable<CloudMessage>;
 
-  private _client: mqtt.MqttClient;
-  private get client(): mqtt.MqttClient {
+  private _client: IMqttClient;
+  private get client(): IMqttClient {
     return this._client;
   }
 
-  private set client(client: mqtt.MqttClient) {
+  private set client(client: IMqttClient) {
     this._client = client;
     const messages = (this.messages = new Subject<CloudMessage>());
 
@@ -37,7 +37,7 @@ export class Connection implements IConnection {
     host: string,
     port: string | number,
     token: string,
-    mqttConnect: (string, IClientOptions) => mqtt.MqttClient
+    mqttConnect: MqttConnect
   ): Promise<IConnection> {
     if (!token) throw new Error('connection failed: you need to provide a valid token');
     if (!host) throw new Error('connection failed: you need to provide a valid host (broker)');
@@ -62,11 +62,11 @@ export class Connection implements IConnection {
     this.client.on(event, cb);
     return this;
   }
-  public end(force?: boolean, opts?: Record<string, any>, cb?: mqtt.CloseCallback): IConnection {
+  public end(force?: boolean, opts?: Record<string, any>, cb?: Function): IConnection {
     this.client.end(force, opts, cb);
     return this;
   }
-  public reconnect(opts?: mqtt.IClientReconnectOptions): IConnection {
+  public reconnect(opts?: object): IConnection {
     this.client.reconnect(opts);
     return this;
   }

--- a/src/connection/IConnection.ts
+++ b/src/connection/IConnection.ts
@@ -1,19 +1,31 @@
 import { Observable } from 'rxjs';
-import {
-  IClientOptions,
-  OnConnectCallback,
-  OnMessageCallback,
-  OnPacketCallback,
-  OnErrorCallback,
-  CloseCallback,
-  IClientReconnectOptions,
-  PacketCallback,
-  IClientPublishOptions,
-} from 'mqtt';
 
 import { CloudMessageValue } from '../client/ICloudClient';
 
-export type ConnectionOptions = IClientOptions;
+export type ConnectionOptions = {
+  port?: number;
+  host?: string;
+  hostname?: string;
+  path?: string;
+  protocol?: 'wss' | 'ws' | 'mqtt' | 'mqtts' | 'tcp' | 'ssl' | 'wx' | 'wxs';
+  wsOptions?: object;
+  keepalive?: number;
+  clientId?: string;
+  protocolId?: string;
+  protocolVersion?: number;
+  clean?: boolean;
+  reconnectPeriod?: number;
+  connectTimeout?: number;
+  username?: string;
+  password?: string;
+  queueQoSZero?: boolean;
+  reschedulePings?: boolean;
+  resubscribe?: boolean;
+  properties?: object;
+  servers?: object;
+  will?: object;
+};
+
 export type CloudMessage = {
   topic: string;
   propertyName?: string;
@@ -24,21 +36,17 @@ export interface IConnection {
   token?: string;
   messages?: Observable<CloudMessage>;
 
-  on(event: 'connect', cb: OnConnectCallback): IConnection;
-  on(event: 'message', cb: OnMessageCallback): IConnection;
-  on(event: 'packetsend' | 'packetreceive', cb: OnPacketCallback): IConnection;
-  on(event: 'error', cb: OnErrorCallback): IConnection;
+  on(event: 'error', cb: (error: Error) => void): IConnection;
   on(event: string, cb: Function): IConnection;
-  on(event: any, cb: any): IConnection;
 
-  end(force?: boolean, opts?: Record<string, any>, cb?: CloseCallback): IConnection;
+  end(force?: boolean, opts?: Record<string, any>, cb?: Function): IConnection;
 
-  reconnect(opts?: IClientReconnectOptions): IConnection;
+  reconnect(opts?: object): IConnection;
 
-  unsubscribe(topic: string | string[], opts?: Record<string, any>, callback?: PacketCallback): IConnection;
+  unsubscribe(topic: string | string[], opts?: Record<string, any>, callback?: Function): IConnection;
 
-  publish(topic: string, message: string | Buffer, opts: IClientPublishOptions, callback?: PacketCallback): IConnection;
-  publish(topic: string, message: string | Buffer, callback?: PacketCallback): IConnection;
+  publish(topic: string, message: string | Buffer, opts: object, callback?: Function): IConnection;
+  publish(topic: string, message: string | Buffer, callback?: Function): IConnection;
   publish(topic: any, message: any, opts?: any, callback?: any): IConnection;
 
   subscribe(topic: any, callback?: any): IConnection;

--- a/src/index.lib.ts
+++ b/src/index.lib.ts
@@ -18,21 +18,24 @@
  *
  */
 
-import SenML from './senML';
-import fetch from 'node-fetch';
 import mqtt from 'mqtt';
+import fetch from 'node-fetch';
 
-import { HttpClientFactory } from './http/HttpClientFactory';
+import SenML from './senML';
 import { CloudClient } from './client/CloudClient';
+import { HttpClientFactory } from './http/HttpClientFactory';
+import { IMqttClient, MqttConnect } from './mqtt/IMqttClient';
 import { APIConnectionBuilder } from './builder/APIConnectionBuilder';
 import { TokenConnectionBuilder } from './builder/TokenConnectionBuilder';
 
-const builders = [
-  new TokenConnectionBuilder(mqtt.connect),
-  new APIConnectionBuilder(HttpClientFactory.Create(fetch), mqtt.connect),
-];
-const ArduinoIoTCloud = new CloudClient(builders);
+const ArduinoIoTCloudFactory = (mqttConnect: MqttConnect) =>
+  new CloudClient([
+    new TokenConnectionBuilder(mqttConnect),
+    new APIConnectionBuilder(HttpClientFactory.Create(fetch), mqttConnect),
+  ]);
 
-export { SenML };
-export { ArduinoIoTCloud };
+const ArduinoIoTCloud = ArduinoIoTCloudFactory(mqtt.connect);
+
+export { SenML, IMqttClient, MqttConnect };
+export { ArduinoIoTCloudFactory, ArduinoIoTCloud };
 export { CloudOptions, CloudMessageValue } from './client/ICloudClient';

--- a/src/index.lib.ts
+++ b/src/index.lib.ts
@@ -23,6 +23,7 @@ import fetch from 'node-fetch';
 
 import SenML from './senML';
 import { CloudClient } from './client/CloudClient';
+import { ConnectionOptions } from './connection/IConnection';
 import { HttpClientFactory } from './http/HttpClientFactory';
 import { IMqttClient, MqttConnect } from './mqtt/IMqttClient';
 import { APIConnectionBuilder } from './builder/APIConnectionBuilder';
@@ -36,6 +37,6 @@ const ArduinoIoTCloudFactory = (mqttConnect: MqttConnect) =>
 
 const ArduinoIoTCloud = ArduinoIoTCloudFactory(mqtt.connect);
 
-export { SenML, IMqttClient, MqttConnect };
 export { ArduinoIoTCloudFactory, ArduinoIoTCloud };
+export { SenML, IMqttClient, MqttConnect, ConnectionOptions };
 export { CloudOptions, CloudMessageValue } from './client/ICloudClient';

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,18 +20,22 @@
 
 import 'whatwg-fetch';
 import mqtt from 'mqtt/dist/mqtt';
+
 import SenML from './senML';
-import { HttpClientFactory } from './http/HttpClientFactory';
 import { CloudClient } from './client/CloudClient';
+import { HttpClientFactory } from './http/HttpClientFactory';
+import { IMqttClient, MqttConnect } from './mqtt/IMqttClient';
 import { APIConnectionBuilder } from './builder/APIConnectionBuilder';
 import { TokenConnectionBuilder } from './builder/TokenConnectionBuilder';
 
-const builders = [
-  new TokenConnectionBuilder(mqtt.connect),
-  new APIConnectionBuilder(HttpClientFactory.Create(fetch), mqtt.connect),
-];
-const ArduinoIoTCloud = new CloudClient(builders);
+const ArduinoIoTCloudFactory = (mqttConnect: MqttConnect) =>
+  new CloudClient([
+    new TokenConnectionBuilder(mqttConnect),
+    new APIConnectionBuilder(HttpClientFactory.Create(fetch), mqttConnect),
+  ]);
 
-export { SenML };
-export { ArduinoIoTCloud };
+const ArduinoIoTCloud = ArduinoIoTCloudFactory(mqtt.connect);
+
+export { SenML, IMqttClient, MqttConnect };
+export { ArduinoIoTCloudFactory, ArduinoIoTCloud };
 export { CloudOptions, CloudMessageValue } from './client/ICloudClient';

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import mqtt from 'mqtt/dist/mqtt';
 
 import SenML from './senML';
 import { CloudClient } from './client/CloudClient';
+import { ConnectionOptions } from './connection/IConnection';
 import { HttpClientFactory } from './http/HttpClientFactory';
 import { IMqttClient, MqttConnect } from './mqtt/IMqttClient';
 import { APIConnectionBuilder } from './builder/APIConnectionBuilder';
@@ -36,6 +37,6 @@ const ArduinoIoTCloudFactory = (mqttConnect: MqttConnect) =>
 
 const ArduinoIoTCloud = ArduinoIoTCloudFactory(mqtt.connect);
 
-export { SenML, IMqttClient, MqttConnect };
 export { ArduinoIoTCloudFactory, ArduinoIoTCloud };
+export { SenML, IMqttClient, MqttConnect, ConnectionOptions };
 export { CloudOptions, CloudMessageValue } from './client/ICloudClient';

--- a/src/mqtt/IMqttClient.ts
+++ b/src/mqtt/IMqttClient.ts
@@ -14,4 +14,4 @@ export interface IMqttClient {
   reconnect(opts?: object): IMqttClient;
 }
 
-export type MqttConnect = (url: string, options: ConnectionOptions) => IMqttClient;
+export type MqttConnect = (url: string, options: ConnectionOptions) => IMqttClient | Promise<IMqttClient>;

--- a/src/mqtt/IMqttClient.ts
+++ b/src/mqtt/IMqttClient.ts
@@ -1,0 +1,17 @@
+import { ConnectionOptions } from '../connection/IConnection';
+
+export interface IMqttClient {
+  on(event: 'error', cb: (error: Error) => void): IMqttClient;
+  on(event: string, cb: Function): IMqttClient;
+
+  publish(topic: string, message: string | Buffer, opts: object, callback?: Function): IMqttClient;
+  publish(topic: string, message: string | Buffer, callback?: Function): IMqttClient;
+
+  end(force?: boolean, opts?: object, cb?: Function): IMqttClient;
+
+  subscribe(topic: string | string[], opts?: object, callback?: Function): IMqttClient;
+
+  reconnect(opts?: object): IMqttClient;
+}
+
+export type MqttConnect = (url: string, options: ConnectionOptions) => IMqttClient;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,69 @@
 import { CloudMessageValue } from '../client/ICloudClient';
 
+// Polyfill btoa/atob for Node.js
+const globalBtoa = typeof btoa !== 'undefined' ? btoa : (str: string) => Buffer.from(str, 'binary').toString('base64');
+const globalAtob = typeof atob !== 'undefined' ? atob : (str: string) => Buffer.from(str, 'base64').toString('binary');
+
+// Universal helper to convert base64 to UTF-8 (no TextDecoder for RN compatibility)
+function base64ToUtf8(base64: string): string {
+  // Use atob as primary (works with RN polyfill)
+  const binaryStr = globalAtob(base64);
+
+  // Try to decode properly with TextDecoder if available
+  try {
+    if (typeof TextDecoder !== 'undefined') {
+      const bytes = new Uint8Array(binaryStr.length);
+      for (let i = 0; i < binaryStr.length; i++) {
+        bytes[i] = binaryStr.charCodeAt(i);
+      }
+      return new TextDecoder().decode(bytes);
+    }
+  } catch (e) {
+    // Fall through
+  }
+  // Fallback: return decoded binary string
+  return binaryStr;
+}
+
+// Universal helper to convert UTF-8 to base64 (no TextEncoder for RN compatibility)
+function utf8ToBase64(utf8: string): string {
+  // Use btoa as primary (works with RN polyfill)
+  // Convert UTF-8 string to binary without using deprecated unescape
+  const encoded = encodeURIComponent(utf8);
+  let binary = '';
+  for (let i = 0; i < encoded.length; i++) {
+    if (encoded[i] === '%') {
+      binary += String.fromCharCode(parseInt(encoded.slice(i + 1, i + 3), 16));
+      i += 2;
+    } else {
+      binary += encoded[i];
+    }
+  }
+  const base64 = globalBtoa(binary);
+
+  // Try to encode properly with TextEncoder if available for better accuracy
+  try {
+    if (typeof TextEncoder !== 'undefined') {
+      const bytes = new TextEncoder().encode(utf8);
+      let binary = '';
+      for (let i = 0; i < bytes.byteLength; i++) {
+        binary += String.fromCharCode(bytes[i]);
+      }
+      return globalBtoa(binary);
+    }
+  } catch (e) {
+    // Fall through
+  }
+  // Fallback: return result from primary btoa approach
+  return base64;
+}
+
+// Universal fallback for Buffer.isBuffer
+function isBufferLike(obj: unknown): boolean {
+  if (typeof Buffer !== 'undefined' && Buffer.isBuffer(obj)) return true;
+  return obj instanceof ArrayBuffer || obj instanceof Uint8Array;
+}
+
 class ArduinoCloudError extends Error {
   constructor(public code: number, message: string) {
     super(message);
@@ -45,7 +109,11 @@ function toArrayBuffer(buf: { length: number }): ArrayBuffer {
 }
 
 function toBuffer(ab: ArrayBuffer): Buffer {
-  const buffer = new Buffer(ab.byteLength);
+  // Node.js only - use Uint8Array in React Native
+  if (typeof Buffer === 'undefined') {
+    throw new Error('toBuffer() requires Node.js environment. Use Uint8Array instead.');
+  }
+  const buffer = Buffer.alloc(ab.byteLength);
   const view = new Uint8Array(ab);
   for (let i = 0; i < buffer.length; ++i) {
     buffer[i] = view[i];
@@ -60,7 +128,7 @@ function arrayBufferToBase64(buf: ArrayBuffer): string {
   for (let i = 0; i < len; i += 1) {
     binary += String.fromCharCode(bytes[i]);
   }
-  return window.btoa(binary);
+  return globalBtoa(binary);
 }
 
 function isValidObject(obj: unknown): obj is object {
@@ -78,12 +146,12 @@ function safeJsonParse(obj: unknown): object {
 
 function headerFromJWS(signature: string): object {
   const encodedHeader = signature.split('.', 1)[0];
-  return safeJsonParse(Buffer.from(encodedHeader, 'base64').toString('binary'));
+  return safeJsonParse(base64ToUtf8(encodedHeader));
 }
 
 function toString(object: unknown): string {
   if (typeof object === 'string') return object;
-  if (typeof object === 'number' || Buffer.isBuffer(object)) return object.toString();
+  if (typeof object === 'number' || isBufferLike(object)) return object.toString();
   return JSON.stringify(object);
 }
 
@@ -94,7 +162,7 @@ function isValidJws(signature: string): boolean {
 
 function payloadFromJWS(signature: string): string {
   const [_, payload] = signature.split('.');
-  return Buffer.from(payload, 'base64').toString('utf8');
+  return base64ToUtf8(payload);
 }
 
 function decode(token: string): string | object {
@@ -123,4 +191,7 @@ export default {
   arrayBufferToBase64,
   isNotAnEmptyObject,
   decode,
+  base64ToUtf8,
+  utf8ToBase64,
+  isBufferLike,
 };


### PR DESCRIPTION
This PR introduces a custom override of the default MQTT client used by the `arduino-iot-js` library.

In certain contexts (specifically when integrating with React Native) the standard MQTT library may cause compatibility issues or fail to build properly.

To address this, I’ve implemented an override using ArduinoIoTCloudFactory, allowing us to inject a custom MQTT client implementation that better suits our environment.

See the README for more info