### PR TITLE
Abstract MQTT client to support custom implementations (e.g. React Native)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,38 +1,48 @@
 name: Release Lib
 
-on: 
+on:
   push:
     tags:
       - '*'
 
 jobs:
-  test:
+  publish-package:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     env:
-      REPO_ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
+      REPO_ACCESS_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     steps:
       - name: Disable EOL conversions
         run: git config --global core.autocrlf false
 
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
 
-      - name: Integration tests
-        uses: actions/setup-node@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
         with:
-          node-version: "18.x"
-          cache: "yarn"
-      
+          node-version: 24
+
       - run: yarn
       - run: yarn lint
       - run: yarn test
         env:
-            CLIENT_ID: ${{ secrets.CLIENT_ID }}
-            CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
-      
+          CLIENT_ID: ${{ secrets.CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
       - run: yarn build
-      - run: npm publish
+      - name: Resolve npm dist-tag
+        id: dist_tag
+        run: |
+          REF="$GITHUB_REF_NAME"
+          PRE=$(echo "$REF" | sed -n 's/.*-\([a-zA-Z][a-zA-Z0-9]*\).*/\1/p')
+          echo "tag=${PRE:-latest}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish NPM Package
+        run: |
+          npm publish --provenance --access public --tag "${{ steps.dist_tag.outputs.tag }}"

--- a/README.md
+++ b/README.md
@@ -112,3 +112,16 @@ import { ArduinoIoTCloud } from 'arduino-iot-js';
   client.onPropertyValue('ANOTHER_VARIABLE_NAME', (value) => console.log(value));
 })();
 ```
+
+## Override MQTT Library
+
+If for any reason (e.g., a `React Native` project) the standard [mqtt library](https://github.com/mqttjs/MQTT.js) causes issues, it's possible to override it using `ArduinoIoTCloudFactory`.
+
+```ts
+import { ArduinoIoTCloudFactory, MqttConnect, ConnectionOptions } from 'arduino-iot-js';
+
+const connect = (url: string, options: ConnectionOptions) => // Put your library here (es. new Paho.MQTT.Client(options.host, Number(options.port)); )
+
+const ArduinoIoTCloud = ArduinoIoTCloudFactory(connect);
+
+```

--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -1,21 +1,21 @@
-import mqtt from 'mqtt';
 import { Observable, Subject } from 'rxjs';
 
 import * as SenML from '../senML';
 import * as Utils from '../utils';
+import { IMqttClient } from '../mqtt/IMqttClient';
 import { CloudMessageValue } from '../client/ICloudClient';
 import { MqttConnection } from '../builder/ICloudClientBuilder';
 import { IConnection, CloudMessage, BaseConnectionOptions, ITokenConnection, ConnectionOptions } from './IConnection';
 export class Connection implements IConnection {
-  private _client: mqtt.MqttClient;
+  private _client: IMqttClient;
   protected options: ConnectionOptions;
   public messages: Observable<CloudMessage>;
 
-  protected get client(): mqtt.MqttClient {
+  protected get client(): IMqttClient {
     return this._client;
   }
 
-  protected set client(client: mqtt.MqttClient) {
+  protected set client(client: IMqttClient) {
     this._client = client;
     const messages = (this.messages = new Subject<CloudMessage>());
 
@@ -53,12 +53,12 @@ export class Connection implements IConnection {
     });
   }
 
-  public end(force?: boolean, opts?: Record<string, any>, cb?: mqtt.CloseCallback): IConnection {
+  public end(force?: boolean, opts?: Record<string, any>, cb?: Function): IConnection {
     this.client.end(force, opts, cb);
     return this;
   }
 
-  public reconnect(opts?: mqtt.IClientReconnectOptions): IConnection {
+  public reconnect(opts?: object): IConnection {
     this.client.reconnect(opts);
     return this;
   }

--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -43,11 +43,10 @@ export class Connection implements IConnection {
     };
   }
 
-  public connect(options?: Partial<ConnectionOptions>): Promise<boolean> {
+  public async connect(options?: Partial<ConnectionOptions>): Promise<boolean> {
+    this.options = options ? { ...this.options, ...options } : this.options;
+    this.client = await this.mqttConnect(this.host, this.options);
     return new Promise<boolean>((res, rej) => {
-      this.options = options ? { ...this.options, ...options } : this.options;
-
-      this.client = this.mqttConnect(this.host, this.options);
       this.client.once('connect', () => res(true));
       this.client.once('close', () => rej(new Error('connection failed: client not connected')));
     });

--- a/src/connection/IConnection.ts
+++ b/src/connection/IConnection.ts
@@ -1,8 +1,31 @@
-import * as mqtt from 'mqtt';
 import { Observable } from 'rxjs';
+
 import { CloudMessageValue } from '../client/ICloudClient';
 
-export type ConnectionOptions = mqtt.IClientOptions;
+export type ConnectionOptions = {
+  port?: number;
+  host?: string;
+  hostname?: string;
+  path?: string;
+  protocol?: 'wss' | 'ws' | 'mqtt' | 'mqtts' | 'tcp' | 'ssl' | 'wx' | 'wxs';
+  wsOptions?: object;
+  keepalive?: number;
+  clientId?: string;
+  protocolId?: string;
+  protocolVersion?: number;
+  clean?: boolean;
+  reconnectPeriod?: number;
+  connectTimeout?: number;
+  username?: string;
+  password?: string;
+  queueQoSZero?: boolean;
+  reschedulePings?: boolean;
+  resubscribe?: boolean;
+  properties?: object;
+  servers?: object;
+  will?: object;
+};
+
 export type CloudMessage = {
   topic: string;
   propertyName?: string;
@@ -21,18 +44,13 @@ export interface IConnection {
   readonly messages?: Observable<CloudMessage>;
 
   subscribe(topic: any, callback?: any): IConnection;
-  reconnect(opts?: mqtt.IClientReconnectOptions): IConnection;
+  reconnect(opts?: object): IConnection;
   connect(options?: Partial<ConnectionOptions>): Promise<boolean>;
-  end(force?: boolean, opts?: Record<string, any>, cb?: mqtt.CloseCallback): IConnection;
-  unsubscribe(topic: string | string[], opts?: Record<string, any>, callback?: mqtt.PacketCallback): IConnection;
+  end(force?: boolean, opts?: Record<string, any>, cb?: Function): IConnection;
+  unsubscribe(topic: string | string[], opts?: Record<string, any>, callback?: Function): IConnection;
 
-  publish(
-    topic: string,
-    message: string | Buffer,
-    opts: mqtt.IClientPublishOptions,
-    callback?: mqtt.PacketCallback
-  ): IConnection;
-  publish(topic: string, message: string | Buffer, callback?: mqtt.PacketCallback): IConnection;
+  publish(topic: string, message: string | Buffer, opts: object, callback?: Function): IConnection;
+  publish(topic: string, message: string | Buffer, callback?: Function): IConnection;
   publish(topic: any, message: any, opts?: any, callback?: any): IConnection;
 }
 

--- a/src/index.lib.ts
+++ b/src/index.lib.ts
@@ -23,6 +23,7 @@ import fetch from 'node-fetch';
 
 import * as SenML from './senML';
 import { ArduinoIoTCloudFactory } from './ArduinoIoTCloud';
+import { ConnectionOptions } from './connection/IConnection';
 import { HttpClientFactory } from './http/HttpClientFactory';
 import { IMqttClient, MqttConnect } from './mqtt/IMqttClient';
 import { APIClientBuilder, APIOptions } from './builder/APIClientBuilder';
@@ -44,7 +45,7 @@ const ArduinoIoTCloud = ArduinoIoTCloudFactory(builders);
 
 export { SenML };
 export { ArduinoIoTCloud };
-export { IMqttClient, MqttConnect };
+export { IMqttClient, MqttConnect, ConnectionOptions };
 export { CloudOptions } from './CloudOptions';
 export { CloudMessageValue } from './client/ICloudClient';
 export { IArduinoIoTCloudFactory } from './builder/IArduinoIoTCloudFactory';

--- a/src/index.lib.ts
+++ b/src/index.lib.ts
@@ -24,6 +24,7 @@ import fetch from 'node-fetch';
 import * as SenML from './senML';
 import { ArduinoIoTCloudFactory } from './ArduinoIoTCloud';
 import { HttpClientFactory } from './http/HttpClientFactory';
+import { IMqttClient, MqttConnect } from './mqtt/IMqttClient';
 import { APIClientBuilder, APIOptions } from './builder/APIClientBuilder';
 import { TokenClientBuilder, BrowserOptions } from './builder/TokenClientBuilder';
 import { CredentialsClientBuilder, CredentialsOptions } from './builder/CredentialsClientBuilder';
@@ -43,6 +44,7 @@ const ArduinoIoTCloud = ArduinoIoTCloudFactory(builders);
 
 export { SenML };
 export { ArduinoIoTCloud };
+export { IMqttClient, MqttConnect };
 export { CloudOptions } from './CloudOptions';
 export { CloudMessageValue } from './client/ICloudClient';
 export { IArduinoIoTCloudFactory } from './builder/IArduinoIoTCloudFactory';

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import mqtt from 'mqtt';
 import * as SenML from './senML';
 import { ArduinoIoTCloudFactory } from './ArduinoIoTCloud';
 import { HttpClientFactory } from './http/HttpClientFactory';
+import { IMqttClient, MqttConnect } from './mqtt/IMqttClient';
 import { APIClientBuilder, APIOptions } from './builder/APIClientBuilder';
 import { TokenClientBuilder, BrowserOptions } from './builder/TokenClientBuilder';
 import { CredentialsClientBuilder, CredentialsOptions } from './builder/CredentialsClientBuilder';
@@ -44,6 +45,7 @@ const ArduinoIoTCloud = ArduinoIoTCloudFactory(builders);
 
 export { SenML };
 export { ArduinoIoTCloud };
+export { IMqttClient, MqttConnect };
 export { CloudOptions } from './CloudOptions';
 export { CloudMessageValue } from './client/ICloudClient';
 export { IArduinoIoTCloudFactory } from './builder/IArduinoIoTCloudFactory';

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import mqtt from 'mqtt';
 
 import * as SenML from './senML';
 import { ArduinoIoTCloudFactory } from './ArduinoIoTCloud';
+import { ConnectionOptions } from './connection/IConnection';
 import { HttpClientFactory } from './http/HttpClientFactory';
 import { IMqttClient, MqttConnect } from './mqtt/IMqttClient';
 import { APIClientBuilder, APIOptions } from './builder/APIClientBuilder';
@@ -45,7 +46,7 @@ const ArduinoIoTCloud = ArduinoIoTCloudFactory(builders);
 
 export { SenML };
 export { ArduinoIoTCloud };
-export { IMqttClient, MqttConnect };
+export { IMqttClient, MqttConnect, ConnectionOptions };
 export { CloudOptions } from './CloudOptions';
 export { CloudMessageValue } from './client/ICloudClient';
 export { IArduinoIoTCloudFactory } from './builder/IArduinoIoTCloudFactory';

--- a/src/mqtt/IMqttClient.ts
+++ b/src/mqtt/IMqttClient.ts
@@ -4,6 +4,9 @@ export interface IMqttClient {
   on(event: 'error', cb: (error: Error) => void): IMqttClient;
   on(event: string, cb: Function): IMqttClient;
 
+  once(event: 'error', cb: (error: Error) => void): IMqttClient;
+  once(event: string, cb: Function): IMqttClient;
+
   publish(topic: string, message: string | Buffer, opts: object, callback?: Function): IMqttClient;
   publish(topic: string, message: string | Buffer, callback?: Function): IMqttClient;
 

--- a/src/mqtt/IMqttClient.ts
+++ b/src/mqtt/IMqttClient.ts
@@ -1,0 +1,17 @@
+import { ConnectionOptions } from '../connection/IConnection';
+
+export interface IMqttClient {
+  on(event: 'error', cb: (error: Error) => void): IMqttClient;
+  on(event: string, cb: Function): IMqttClient;
+
+  publish(topic: string, message: string | Buffer, opts: object, callback?: Function): IMqttClient;
+  publish(topic: string, message: string | Buffer, callback?: Function): IMqttClient;
+
+  end(force?: boolean, opts?: object, cb?: Function): IMqttClient;
+
+  subscribe(topic: string | string[], opts?: object, callback?: Function): IMqttClient;
+
+  reconnect(opts?: object): IMqttClient;
+}
+
+export type MqttConnect = (url: string, options: ConnectionOptions) => IMqttClient;

--- a/src/mqtt/IMqttClient.ts
+++ b/src/mqtt/IMqttClient.ts
@@ -17,4 +17,4 @@ export interface IMqttClient {
   reconnect(opts?: object): IMqttClient;
 }
 
-export type MqttConnect = (url: string, options: ConnectionOptions) => IMqttClient;
+export type MqttConnect = (url: string, options: ConnectionOptions) => IMqttClient | Promise<IMqttClient>;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,69 @@
 import { CloudMessageValue } from '../client/ICloudClient';
 
+// Polyfill btoa/atob for Node.js
+const globalBtoa = typeof btoa !== 'undefined' ? btoa : (str: string) => Buffer.from(str, 'binary').toString('base64');
+const globalAtob = typeof atob !== 'undefined' ? atob : (str: string) => Buffer.from(str, 'base64').toString('binary');
+
+// Universal helper to convert base64 to UTF-8 (no TextDecoder for RN compatibility)
+export function base64ToUtf8(base64: string): string {
+  // Use atob as primary (works with RN polyfill)
+  const binaryStr = globalAtob(base64);
+
+  // Try to decode properly with TextDecoder if available
+  try {
+    if (typeof TextDecoder !== 'undefined') {
+      const bytes = new Uint8Array(binaryStr.length);
+      for (let i = 0; i < binaryStr.length; i++) {
+        bytes[i] = binaryStr.charCodeAt(i);
+      }
+      return new TextDecoder().decode(bytes);
+    }
+  } catch (e) {
+    // Fall through
+  }
+  // Fallback: return decoded binary string
+  return binaryStr;
+}
+
+// Universal helper to convert UTF-8 to base64 (no TextEncoder for RN compatibility)
+export function utf8ToBase64(utf8: string): string {
+  // Use btoa as primary (works with RN polyfill)
+  // Convert UTF-8 string to binary without using deprecated unescape
+  const encoded = encodeURIComponent(utf8);
+  let binary = '';
+  for (let i = 0; i < encoded.length; i++) {
+    if (encoded[i] === '%') {
+      binary += String.fromCharCode(parseInt(encoded.slice(i + 1, i + 3), 16));
+      i += 2;
+    } else {
+      binary += encoded[i];
+    }
+  }
+  const base64 = globalBtoa(binary);
+
+  // Try to encode properly with TextEncoder if available for better accuracy
+  try {
+    if (typeof TextEncoder !== 'undefined') {
+      const bytes = new TextEncoder().encode(utf8);
+      let binary = '';
+      for (let i = 0; i < bytes.byteLength; i++) {
+        binary += String.fromCharCode(bytes[i]);
+      }
+      return globalBtoa(binary);
+    }
+  } catch (e) {
+    // Fall through
+  }
+  // Fallback: return result from primary btoa approach
+  return base64;
+}
+
+// Universal fallback for Buffer.isBuffer
+export function isBufferLike(obj: unknown): boolean {
+  if (typeof Buffer !== 'undefined' && Buffer.isBuffer(obj)) return true;
+  return obj instanceof ArrayBuffer || obj instanceof Uint8Array;
+}
+
 export class ArduinoCloudError extends Error {
   constructor(public code: number, message: string) {
     super(message);
@@ -49,6 +113,10 @@ export function toArrayBuffer(buf: { length: number }): ArrayBuffer {
 }
 
 export function toBuffer(ab: ArrayBuffer): Buffer {
+  // Node.js only - use Uint8Array in React Native
+  if (typeof Buffer === 'undefined') {
+    throw new Error('toBuffer() requires Node.js environment. Use Uint8Array instead.');
+  }
   const buffer = Buffer.alloc(ab.byteLength);
   const view = new Uint8Array(ab);
   for (let i = 0; i < buffer.length; ++i) {
@@ -64,7 +132,7 @@ export function arrayBufferToBase64(buf: ArrayBuffer): string {
   for (let i = 0; i < len; i += 1) {
     binary += String.fromCharCode(bytes[i]);
   }
-  return window.btoa(binary);
+  return globalBtoa(binary);
 }
 
 export interface Newable<T> {
@@ -86,12 +154,12 @@ export function safeJsonParse(obj: unknown): object {
 
 export function headerFromJWS(signature: string): object {
   const encodedHeader = signature.split('.', 1)[0];
-  return safeJsonParse(Buffer.from(encodedHeader, 'base64').toString('binary'));
+  return safeJsonParse(base64ToUtf8(encodedHeader));
 }
 
 export function toString(object: unknown): string {
   if (typeof object === 'string') return object;
-  if (typeof object === 'number' || Buffer.isBuffer(object)) return object.toString();
+  if (typeof object === 'number' || isBufferLike(object)) return object.toString();
   return JSON.stringify(object);
 }
 
@@ -102,7 +170,7 @@ export function isValidJws(signature: string): boolean {
 
 export function payloadFromJWS(signature: string): string {
   const [_, payload] = signature.split('.');
-  return Buffer.from(payload, 'base64').toString('utf8');
+  return base64ToUtf8(payload);
 }
 
 export function decode(token: string): string | object {


### PR DESCRIPTION
Summary

- Introduce IMqttClient interface and MqttConnect type so consumers can plug in any MQTT implementation instead of depending on the mqtt package internals. MqttConnect accepts both sync and Promise-returning factories.

- Make ConnectionOptions self-contained (no longer aliased to mqtt.IClientOptions) and export it alongside IMqttClient / MqttConnect from the public entry points.

- Replace direct Buffer / window.btoa usage in src/utils with globalBtoa/globalAtob polyfills plus base64ToUtf8 / utf8ToBase64 / isBufferLike helpers, so token decoding works in React Native and other non-Node runtimes.

- Document the override path in the README via ArduinoIoTCloudFactory(connect).