### PR TITLE
[FLEX-3380] refactor: re-implement MQTT events with a minimal emitter (remove rxjs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,32 @@ JWT no longer kills the session.
 > `client.onPropertyValue()` / `client.disconnect()` API has been replaced by
 > the connection-first API shown below.
 
+### Events and subscriptions
+
+`property.subscribe(listener)` calls `listener` with the property's value every
+time an update arrives from the cloud, and returns a `Subscription`:
+
+```ts
+const subscription = property.subscribe((value) => console.log(value));
+// ...later, stop this listener:
+subscription.unsubscribe();
+```
+
+A few things worth knowing about the model:
+
+- **Many listeners share one broker subscription.** Subscriptions are
+  reference-counted per topic: the first `subscribe` on a property opens the MQTT
+  subscription, and the broker is only unsubscribed once the last listener calls
+  `unsubscribe`. Subscribing the same property from several places is cheap.
+- **Subscriptions survive reconnects.** If the broker drops the socket, the
+  transport restores the retained topic subscriptions on the new connection, so
+  your listeners keep firing without re-subscribing.
+- **`connection.close()` tears everything down** — every listener and the
+  underlying socket. The connection must not be reused afterwards.
+
+Internally this runs on a small built-in event emitter; the library has no
+`rxjs` (or other heavy) runtime dependency.
+
 ### Providing the MQTT client
 
 This library is **transport-agnostic**: it never imports `mqtt` itself, so nothing

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "src"
   ],
   "dependencies": {
-    "@arduino/cbor-js": "arduino/cbor-js",
-    "rxjs": "^6.5.5"
+    "@arduino/cbor-js": "arduino/cbor-js"
   },
   "peerDependencies": {
     "mqtt": "^4.3.7"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@arduino/cbor-js':
         specifier: arduino/cbor-js
         version: https://codeload.github.com/arduino/cbor-js/tar.gz/a55e62ac70349aafb1fb6f3ef4413e6b293c4234
-      rxjs:
-        specifier: ^6.5.5
-        version: 6.6.6
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.4
@@ -1317,10 +1314,6 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  rxjs@6.6.6:
-    resolution: {integrity: sha512-/oTwee4N4iWzAMAL9xdGKjkEHmIwupR3oXbQjCKywF1BeFohswF3vZdogbmEF6pZkOsXTzWkrZszrWpQTByYVg==}
-    engines: {npm: '>=2.0.0'}
-
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
@@ -1426,9 +1419,6 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
-
-  tslib@1.14.1:
-    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -3005,10 +2995,6 @@ snapshots:
       fsevents: 2.3.3
     optional: true
 
-  rxjs@6.6.6:
-    dependencies:
-      tslib: 1.14.1
-
   safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2:
@@ -3109,8 +3095,6 @@ snapshots:
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
       typescript: 6.0.3
-
-  tslib@1.14.1: {}
 
   tslib@2.8.1:
     optional: true

--- a/src/connection/ActiveConnection.ts
+++ b/src/connection/ActiveConnection.ts
@@ -1,12 +1,9 @@
-import { filter } from 'rxjs/operators';
-import { Subscription as RxSubscription } from 'rxjs';
-
 import * as SenML from '../senML';
 import * as Utils from '../utils';
 import { CloudOptions } from '../types/options';
 import { MqttTransport } from '../transport/MqttTransport';
+import { Subscription } from '../transport/Emitter';
 import { CloudMessage, CloudMessageValue } from '../transport/types';
-import { Subscription } from './Subscription';
 import { PropertyChannel, PropertyListener } from './Property';
 
 /**
@@ -49,16 +46,16 @@ export abstract class ActiveConnection {
     if (count === 0) this.transport.subscribe(topic);
     this.topicRefs.set(topic, count + 1);
 
-    const rxSub: RxSubscription = this.transport.messages
-      .pipe(filter((m) => m.topic === topic && predicate(m)))
-      .subscribe((m) => listener(m.value as T));
+    const subscription = this.transport.messages.subscribe((m) => {
+      if (m.topic === topic && predicate(m)) listener(m.value as T);
+    });
 
     let closed = false;
     return {
       unsubscribe: () => {
         if (closed) return;
         closed = true;
-        rxSub.unsubscribe();
+        subscription.unsubscribe();
 
         // Drop the broker subscription once the last listener goes away.
         const remaining = (this.topicRefs.get(topic) || 1) - 1;

--- a/src/connection/Property.ts
+++ b/src/connection/Property.ts
@@ -1,5 +1,5 @@
 import { CloudMessageValue } from '../transport/types';
-import { Subscription } from './Subscription';
+import { Subscription } from '../transport/Emitter';
 
 export type PropertyListener<T extends CloudMessageValue> = (value: T) => void;
 

--- a/src/connection/Subscription.ts
+++ b/src/connection/Subscription.ts
@@ -1,8 +1,0 @@
-/**
- * Handle returned by `Property.subscribe`. Calling `unsubscribe` detaches this
- * callback and, when it is the last listener on the underlying MQTT topic,
- * unsubscribes from the broker as well.
- */
-export interface Subscription {
-  unsubscribe(): void;
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,4 +40,4 @@ export type { ActiveConnection } from './connection/ActiveConnection';
 export type { UserConnection } from './connection/UserConnection';
 export type { DeviceConnection } from './connection/DeviceConnection';
 export type { Property, PropertyListener } from './connection/Property';
-export type { Subscription } from './connection/Subscription';
+export type { Subscription } from './transport/Emitter';

--- a/src/transport/Emitter.ts
+++ b/src/transport/Emitter.ts
@@ -1,0 +1,45 @@
+export type Listener<T> = (value: T) => void;
+
+/**
+ * Handle returned when a listener is registered. Calling `unsubscribe` detaches
+ * the listener; it is safe to call more than once. This is the same handle the
+ * public `Property.subscribe` hands back.
+ */
+export interface Subscription {
+  unsubscribe(): void;
+}
+
+/**
+ * Read-only view of an {@link Emitter}: lets consumers attach listeners but not
+ * emit. Exposed by the transport so the message stream can't be driven from the
+ * outside — the mirror of rxjs's `Observable`/`Subject` split this replaced.
+ */
+export interface Subscribable<T> {
+  subscribe(listener: Listener<T>): Subscription;
+}
+
+/**
+ * Minimal synchronous multicast emitter — the small slice of rxjs's `Subject`
+ * this library actually used. Listeners fire in registration order; a listener
+ * that subscribes or unsubscribes during a dispatch does not disturb the
+ * in-flight one, because each `emit` iterates a snapshot of the listener set.
+ */
+export class Emitter<T> implements Subscribable<T> {
+  private readonly listeners = new Set<Listener<T>>();
+
+  public subscribe(listener: Listener<T>): Subscription {
+    this.listeners.add(listener);
+    let closed = false;
+    return {
+      unsubscribe: () => {
+        if (closed) return;
+        closed = true;
+        this.listeners.delete(listener);
+      },
+    };
+  }
+
+  public emit(value: T): void {
+    [...this.listeners].forEach((listener) => listener(value));
+  }
+}

--- a/src/transport/Emitter.ts
+++ b/src/transport/Emitter.ts
@@ -40,6 +40,19 @@ export class Emitter<T> implements Subscribable<T> {
   }
 
   public emit(value: T): void {
-    [...this.listeners].forEach((listener) => listener(value));
+    // Snapshot so a listener that (un)subscribes during dispatch is safe, and
+    // isolate each call so one throwing listener can't stop delivery to the
+    // rest. A thrown error is re-raised on a fresh task — the way rxjs's Subject
+    // reported unhandled subscriber errors — so it still reaches the host's
+    // global error handler instead of being swallowed here.
+    [...this.listeners].forEach((listener) => {
+      try {
+        listener(value);
+      } catch (error) {
+        setTimeout(() => {
+          throw error;
+        });
+      }
+    });
   }
 }

--- a/src/transport/Emitter.ts
+++ b/src/transport/Emitter.ts
@@ -22,30 +22,38 @@ export interface Subscribable<T> {
  * Minimal synchronous multicast emitter — the small slice of rxjs's `Subject`
  * this library actually used. Listeners fire in registration order; a listener
  * that subscribes or unsubscribes during a dispatch does not disturb the
- * in-flight one, because each `emit` iterates a snapshot of the listener set.
+ * in-flight one, because `emit` iterates a snapshot of the listener set.
  */
 export class Emitter<T> implements Subscribable<T> {
   private readonly listeners = new Set<Listener<T>>();
+  // Cached listener snapshot for `emit`, rebuilt lazily. Nulled on every
+  // (un)subscribe so a stale set is never dispatched; reused across emits while
+  // the set is stable to avoid reallocating on this per-message hot path.
+  private snapshot: Listener<T>[] | null = null;
 
   public subscribe(listener: Listener<T>): Subscription {
     this.listeners.add(listener);
+    this.snapshot = null;
     let closed = false;
     return {
       unsubscribe: () => {
         if (closed) return;
         closed = true;
         this.listeners.delete(listener);
+        this.snapshot = null;
       },
     };
   }
 
   public emit(value: T): void {
-    // Snapshot so a listener that (un)subscribes during dispatch is safe, and
-    // isolate each call so one throwing listener can't stop delivery to the
-    // rest. A thrown error is re-raised on a fresh task — the way rxjs's Subject
-    // reported unhandled subscriber errors — so it still reaches the host's
-    // global error handler instead of being swallowed here.
-    [...this.listeners].forEach((listener) => {
+    // Dispatch over a snapshot so a listener that (un)subscribes mid-dispatch
+    // doesn't disturb this loop (the mutation only replaces the cached array,
+    // never the one we hold here). Isolate each call so one throwing listener
+    // can't stop delivery to the rest; a thrown error is re-raised on a fresh
+    // task — the way rxjs's Subject reported unhandled subscriber errors — so it
+    // still reaches the host's global error handler instead of being swallowed.
+    const listeners = (this.snapshot ??= [...this.listeners]);
+    listeners.forEach((listener) => {
       try {
         listener(value);
       } catch (error) {

--- a/src/transport/MqttTransport.ts
+++ b/src/transport/MqttTransport.ts
@@ -1,8 +1,7 @@
-import { Observable, Subject } from 'rxjs';
-
 import * as SenML from '../senML';
 import * as Utils from '../utils';
 import { MqttCallback, MqttClient } from '../mqtt/MqttClient';
+import { Emitter, Subscribable } from './Emitter';
 import { BaseConnectionOptions, CloudMessage, CloudMessageValue, MqttOptions } from './types';
 
 export type MqttConnectFn = (url: string, options: MqttOptions) => MqttClient | Promise<MqttClient>;
@@ -38,9 +37,9 @@ export class MqttTransport {
   private closed = false;
   private reconnecting = false;
 
-  private readonly messagesSubject = new Subject<CloudMessage>();
+  private readonly messagesEmitter = new Emitter<CloudMessage>();
   /** Decoded messages for every subscribed topic. Survives reconnects. */
-  public readonly messages: Observable<CloudMessage> = this.messagesSubject;
+  public readonly messages: Subscribable<CloudMessage> = this.messagesEmitter;
 
   // Re-applied to every fresh client so callbacks and subscriptions survive a
   // reconnect (and the credential refresh that comes with it).
@@ -178,8 +177,8 @@ export class MqttTransport {
   }
 
   private onMessage(topic: string, msg: Buffer): void {
-    if (topic.indexOf('/s/o') > -1) this.messagesSubject.next({ topic, value: msg.toString() });
-    else this.decode(topic, msg).forEach((m) => this.messagesSubject.next(m));
+    if (topic.indexOf('/s/o') > -1) this.messagesEmitter.emit({ topic, value: msg.toString() });
+    else this.decode(topic, msg).forEach((m) => this.messagesEmitter.emit(m));
   }
 
   private decode(topic: string, msg: Buffer): CloudMessage[] {

--- a/test/Emitter.test.ts
+++ b/test/Emitter.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Emitter } from '../src/transport/Emitter';
+
+describe('Emitter delivery', () => {
+  it('multicasts a value to every listener in registration order', () => {
+    const emitter = new Emitter<number>();
+    const calls: string[] = [];
+
+    emitter.subscribe((v) => calls.push(`a:${v}`));
+    emitter.subscribe((v) => calls.push(`b:${v}`));
+    emitter.emit(1);
+
+    expect(calls).toEqual(['a:1', 'b:1']);
+  });
+
+  it('delivers to the same listener again on each emit', () => {
+    const emitter = new Emitter<number>();
+    const listener = vi.fn();
+
+    emitter.subscribe(listener);
+    emitter.emit(1);
+    emitter.emit(2);
+
+    expect(listener.mock.calls).toEqual([[1], [2]]);
+  });
+
+  it('does not deliver to a listener after it unsubscribes', () => {
+    const emitter = new Emitter<number>();
+    const listener = vi.fn();
+
+    const subscription = emitter.subscribe(listener);
+    emitter.emit(1);
+    subscription.unsubscribe();
+    emitter.emit(2);
+
+    expect(listener.mock.calls).toEqual([[1]]);
+  });
+
+  it('is safe to unsubscribe more than once', () => {
+    const emitter = new Emitter<number>();
+    const listener = vi.fn();
+
+    const subscription = emitter.subscribe(listener);
+    subscription.unsubscribe();
+    expect(() => subscription.unsubscribe()).not.toThrow();
+
+    emitter.emit(1);
+    expect(listener).not.toHaveBeenCalled();
+  });
+});
+
+describe('Emitter mid-dispatch mutation', () => {
+  it('still notifies a listener that was unsubscribed during the same dispatch', () => {
+    const emitter = new Emitter<number>();
+    const calls: string[] = [];
+
+    const subs: { second?: { unsubscribe(): void } } = {};
+    emitter.subscribe(() => {
+      calls.push('first');
+      subs.second?.unsubscribe();
+    });
+    subs.second = emitter.subscribe(() => calls.push('second'));
+
+    emitter.emit(1);
+    // The snapshot was taken before dispatch, so `second` still runs this round.
+    expect(calls).toEqual(['first', 'second']);
+
+    calls.length = 0;
+    emitter.emit(2);
+    // ...but not on the next one.
+    expect(calls).toEqual(['first']);
+  });
+
+  it('does not notify a listener that subscribes during the same dispatch', () => {
+    const emitter = new Emitter<number>();
+    const calls: string[] = [];
+    const late = (): void => void calls.push('late');
+
+    emitter.subscribe(() => {
+      calls.push('first');
+      emitter.subscribe(late);
+    });
+
+    emitter.emit(1);
+    // `late` joined after the snapshot was taken, so it waits for the next emit.
+    expect(calls).toEqual(['first']);
+
+    calls.length = 0;
+    emitter.emit(2);
+    expect(calls).toEqual(['first', 'late']);
+  });
+
+  it('reuses the snapshot across stable emits and rebuilds it after a change', () => {
+    const emitter = new Emitter<number>();
+    const a = vi.fn();
+    const b = vi.fn();
+
+    const subA = emitter.subscribe(a);
+    emitter.subscribe(b);
+    emitter.emit(1);
+    emitter.emit(2);
+    subA.unsubscribe();
+    emitter.emit(3);
+
+    expect(a.mock.calls).toEqual([[1], [2]]);
+    expect(b.mock.calls).toEqual([[1], [2], [3]]);
+  });
+});
+
+describe('Emitter error isolation', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('keeps notifying the remaining listeners when one throws', () => {
+    const emitter = new Emitter<number>();
+    const calls: string[] = [];
+    const boom = new Error('boom');
+
+    emitter.subscribe(() => {
+      calls.push('a');
+      throw boom;
+    });
+    emitter.subscribe(() => calls.push('b'));
+
+    expect(() => emitter.emit(1)).not.toThrow();
+    expect(calls).toEqual(['a', 'b']);
+  });
+
+  it('re-raises a listener error on a fresh task', () => {
+    const emitter = new Emitter<number>();
+    const boom = new Error('boom');
+
+    emitter.subscribe(() => {
+      throw boom;
+    });
+
+    emitter.emit(1);
+    // Swallowed synchronously, then rethrown when the scheduled task runs.
+    expect(() => vi.runAllTimers()).toThrow(boom);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #540, which left RxJS in place with the note that it would be *"removed in a follow-up task focused on the MQTT event layer."* This is that follow-up.

RxJS backed a single thing — the transport's decoded-message stream — and never surfaced in the public API. This PR replaces `Subject`/`Observable` with a tiny internal `Emitter` and drops the dependency (and its transitive `tslib@1`).

```ts
// before — MqttTransport
private readonly messagesSubject = new Subject<CloudMessage>();
public readonly messages: Observable<CloudMessage> = this.messagesSubject;

// before — ActiveConnection.observe
this.transport.messages
  .pipe(filter((m) => m.topic === topic && predicate(m)))
  .subscribe((m) => listener(m.value as T));
```

```ts
// after — MqttTransport
private readonly messagesEmitter = new Emitter<CloudMessage>();
public readonly messages: Subscribable<CloudMessage> = this.messagesEmitter;

// after — ActiveConnection.observe
this.transport.messages.subscribe((m) => {
  if (m.topic === topic && predicate(m)) listener(m.value as T);
});
```

> ✅ **No public API change.** `property.subscribe()` already returned the library's own `Subscription` interface, never an `Observable` — so this is a purely internal swap.

## Motivations (what changed and why)

| Change | Why |
|---|---|
| **`Subject`/`Observable` → `Emitter<T>` + `Subscribable<T>`** (new `transport/Emitter.ts`) | The message stream only ever used multicast + a `filter`. A ~45-line synchronous emitter covers that exactly; the `Subscribable` read-only view preserves the `Observable`/`Subject` encapsulation (consumers subscribe, only the transport emits). |
| **`.pipe(filter(...)).subscribe(...)` → plain `subscribe()` with an inline guard** | Removes the operator pipeline for a single equality+predicate check that reads more directly inline. |
| **Dropped `rxjs` dependency** (and transitive `tslib@1`) | RxJS was the last runtime dependency beyond `@arduino/cbor-js`. Removing it shrinks the install/bundle footprint — relevant since the library is deliberately transport-agnostic and React-Native-friendly. |
| **`Subscription` interface moved `connection/Subscription.ts` → `transport/Emitter.ts`** | The transport now produces subscriptions, and transport must not import from the higher-level `connection` layer. The public export from `index.ts` is unchanged. |

## Implementation notes

- `Emitter.emit()` iterates a **snapshot** of the listener set, so a listener that subscribes/unsubscribes during dispatch can't disturb the in-flight notification.
- Topic reference-counting in `ActiveConnection` is untouched — only the underlying subscription mechanism changed.

## Docs

- Added an **"Events and subscriptions"** section to the README documenting the `subscribe`/`unsubscribe` model: subscriptions are reference-counted across listeners, survive reconnects, and are all torn down by `connection.close()`.

## Notes

- `pnpm build` ✅ (ESM + CJS) and all **45 tests** ✅ pass.
