### PR TITLE
[FLEX-3260] ci: add `licensed` action for licenses retrieval

### DIFF
--- a/.github/actions/setup-bot/action.yml
+++ b/.github/actions/setup-bot/action.yml
@@ -1,0 +1,17 @@
+name: Setup Bot Identity
+description: Configures git to use ArduinoBot identity
+
+inputs:
+  token:
+    description: Bot token
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Configure git identity
+      shell: bash
+      run: |
+        git config --global user.name "ArduinoBot"
+        git config --global user.email "4233897+ArduinoBot@users.noreply.github.com"
+        git config --global url.https://x-oauth-basic:${{ inputs.token }}@github.com/.insteadOf https://github.com/

--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -1,0 +1,71 @@
+name: 📃 Update licenses
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - ".licensed.yml"
+
+jobs:
+  update-licenses:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: ✅ Checkout
+        id: checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - name: 📦 Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: 🤖 Setup bot
+        uses: ./.github/actions/setup-bot
+        with:
+          token: ${{ secrets.ARDUINOBOT_TOKEN }}
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ruby
+
+      - name: 📃 Setup licensed
+        uses: licensee/setup-licensed@v1.3.2
+        with:
+          github_token: ${{ secrets.ARDUINOBOT_TOKEN }}
+          version: 5.x
+
+      - name: 📃 Update licenses
+        id: update-licenses
+        uses: licensee/licensed-ci@v1.12.1
+        continue-on-error: true
+        with:
+          commit_message: "chore: update licenses"
+          workflow: "branch"
+          github_token: ${{ secrets.ARDUINOBOT_TOKEN }}
+
+      - name: 📃 Update missing licenses
+        if: steps.update-licenses.outputs.pr_number != ''
+        run: |
+          bash scripts/resolve-missing-licenses.sh
+          # If there are changes, commit and push them to the PR branch.
+          pr_branch="${{ steps.update-licenses.outputs.licenses_branch }}"
+          git checkout --track origin/"$pr_branch"
+          if [ -n "$(git status --porcelain)" ]; then
+            git add .
+            git commit -m "fix: update missing licenses"
+            git push origin "$pr_branch"
+          else
+            echo "No license updates needed."
+          fi

--- a/.licensed.yml
+++ b/.licensed.yml
@@ -1,0 +1,32 @@
+sources:
+  pnpm: true
+
+allowed:
+  - mit
+  - apache-2.0
+  - bsd-2-clause
+  - bsd-3-clause
+  - isc
+  - unlicense
+  - wtfpl
+  - 0bsd
+  - zlib
+  - bsl-1.0
+  - mpl-2.0
+  - epl-2.0
+  - cddl-1.0
+  - gpl-1.0-only
+  - gpl-1.0-or-later
+  - gpl-2.0-only
+  - gpl-2.0-or-later
+  - gpl-3.0-only
+  - gpl-3.0-or-later
+  - lgpl-3.0-linking-exception
+  - cc-by-4.0
+  # The following licenses were parsed from `other`
+  - cc0-1.0
+  - python-2.0
+  - gplv3
+
+apps:
+  - source_path: ./

--- a/.licenses/arduino-iot-js/pnpm/@arduino/cbor-js@0.1.5.dep.yml
+++ b/.licenses/arduino-iot-js/pnpm/@arduino/cbor-js@0.1.5.dep.yml
@@ -1,0 +1,33 @@
+---
+name: "@arduino/cbor-js"
+version: 0.1.5
+type: pnpm
+summary: The Concise Binary Object Representation (CBOR) data format (RFC7049) implemented
+  in pure JavaScript.
+homepage: https://github.com/arduino/cbor-js
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    The MIT License (MIT)
+
+    Copyright (c) 2014 Patrick Gansterer <paroga@paroga.com>
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+notices: []

--- a/scripts/resolve-missing-licenses.sh
+++ b/scripts/resolve-missing-licenses.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Resolve "other" licenses by fetching the license info from the NPM registry.
+# Usage: ./scripts/resolve-missing-licenses.sh
+# Dependencies: bash 4+, curl, jq
+set -euo pipefail
+
+# ── Spinner ──────────────────────────────────────────────────────────────────
+
+_spin_frames=('⠋' '⠙' '⠹' '⠸' '⠼' '⠴' '⠦' '⠧' '⠇' '⠏')
+_spin_i=0
+
+spinner_tick() {
+  local msg=$1
+  printf '\r  %s %s' "${_spin_frames[$((_spin_i % ${#_spin_frames[@]}))]}" "$msg"
+  _spin_i=$((_spin_i + 1))
+}
+
+spinner_clear() { printf '\r\033[K'; }
+
+# Runs a command in the background, shows a spinner, then captures its output.
+# Usage: with_spinner <msg> <output_var> -- <cmd> [args...]
+with_spinner() {
+  local msg=$1 outvar=$2
+  shift 3  # skip msg, outvar, and '--'
+  local tmpfile
+  tmpfile=$(mktemp)
+  "$@" >"$tmpfile" 2>/dev/null &
+  local pid=$!
+  while kill -0 "$pid" 2>/dev/null; do
+    spinner_tick "$msg"
+    sleep 0.08
+  done
+  wait "$pid"
+  spinner_clear
+  printf -v "$outvar" '%s' "$(cat "$tmpfile")"
+  rm -f "$tmpfile"
+}
+
+# ── Collect files ─────────────────────────────────────────────────────────────
+
+mapfile -t files < <(grep -rl '^license: other' .licenses/ 2>/dev/null | sort)
+total=${#files[@]}
+
+if (( total == 0 )); then
+  echo "No files to process."
+  exit 0
+fi
+
+echo "Found $total file(s) with unresolved 'other' license."
+echo ""
+
+count=0
+updated=0
+failed=0
+
+# ── Process each file ─────────────────────────────────────────────────────────
+
+for file in "${files[@]}"; do
+  count=$((count + 1))
+
+  package_name=$(grep -m1 '^name: ' "$file" | sed 's/^name: //' | tr -d '\r"' || true)
+  if [ -z "$package_name" ] || [ "$package_name" = "null" ]; then
+    echo "  ✗ [$count/$total] $file — no valid package name, skipping"
+    failed=$((failed + 1))
+    continue
+  fi
+
+  version=$(grep -m1 '^version: ' "$file" | sed 's/^version: //' | tr -d '\r"' || true)
+  if [ -z "$version" ] || [ "$version" = "null" ]; then
+    echo "  ✗ [$count/$total] $package_name — no valid version, skipping"
+    failed=$((failed + 1))
+    continue
+  fi
+
+  registry_url="https://registry.npmjs.org/$package_name/$version"
+
+  with_spinner "[$count/$total] Fetching $package_name@$version ..." registry_data \
+    -- curl --max-time 10 -s "$registry_url"
+
+  if ! printf '%s' "$registry_data" | jq -e . >/dev/null 2>&1; then
+    echo "  ✗ [$count/$total] $package_name@$version — failed to fetch registry data"
+    failed=$((failed + 1))
+    continue
+  fi
+
+  got_license=$(printf '%s' "$registry_data" | jq -r '
+    .license |
+    if type == "string" then .
+    elif type == "object" then .type
+    elif type == "array" then (.[0].type // .[0])
+    else empty end
+  ' 2>/dev/null || true)
+
+  if [ -n "$got_license" ] && [ "$got_license" != "null" ]; then
+    norm_license=$(printf '%s' "$got_license" | tr '[:upper:]' '[:lower:]')
+    # Portable in-place sed: write to tmp then move (avoids macOS/Linux sed -i differences).
+    # Use | as delimiter since license strings can contain /.
+    local_tmp=$(mktemp)
+    sed "s|^license: other$|license: ${norm_license}|" "$file" > "$local_tmp"
+    mv "$local_tmp" "$file"
+    echo "  ✓ [$count/$total] $package_name@$version → $norm_license"
+    updated=$((updated + 1))
+  else
+    echo "  ✗ [$count/$total] $package_name@$version — could not resolve license from registry"
+    failed=$((failed + 1))
+  fi
+done
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo "Done. Updated: $updated  |  Failed: $failed  |  Total: $total"


### PR DESCRIPTION
FLEX-3260

This PR adds support for `licensed`, running on dependencies changes pushed to `master`.
Opens a PR if necessary.

Currently, we have:
`1 dependencies checked, 0 errors found.`

<details>

<summary>`licensed status` output</summary>

```sh
❯ licensed status
Checking cached dependency records for arduino-iot-js
.
1 dependencies checked, 0 errors found.
```

</details>

Only one dependency is enumerated because this is a library: the only production dependency is `@arduino/cbor-js` (`mit`). `mqtt` is an optional `peerDependency`, so `licensed` doesn't enumerate it — it gets recorded by the consumer app instead (in `cloud-website` it shows up alongside `arduino-iot-js` itself).

As a consequence there are no `other` licenses to resolve right now, so `scripts/resolve-missing-licenses.sh` has nothing to do — it's in place for when the dependency list grows.

Aligned with the current state of [cloud-apps#585](https://github.com/bcmi-labs/cloud-apps/pull/585) and [cloud-website#487](https://github.com/bcmi-labs/cloud-website/pull/487), including the fixes that landed after those PRs (`continue-on-error`, `pr_number != ''`, `licenses_branch`, `git checkout --track`). `scripts/resolve-missing-licenses.sh` is copied verbatim from both.

Differences, due to this repo's setup:
- trigger is on `master` instead of `main`
- there's no `./.github/actions/prepare` composite action here, so the workflow uses `pnpm/action-setup@v4` + `actions/setup-node@v6` (node 24) like the other workflows in this repo
- `.licensed.yml` has no `ignored`/`reviewed` sections: there are no private `@bcmi-labs/*` packages nor highcharts

> [!NOTE]
> The workflow needs the `ARDUINOBOT_TOKEN` secret. Worth double-checking it's available on `arduino/arduino-iot-js`, since this repo lives in the `arduino` org rather than `bcmi-labs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)